### PR TITLE
Adjusting default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,12 @@ endif
 next := $(draft)-$(next_ver)
 diff_ver := $(draft)-$(current_ver)
 
-.PHONY: latest submit diff clean
+.PHONY: latest txt html pdf submit diff clean
 
-latest: $(draft).txt $(draft).html $(draft).pdf
+latest: txt html
+txt: $(draft).txt
+html: $(draft).html
+pdf: $(draft).pdf 
 
 submit: $(next).txt
 


### PR DESCRIPTION
The addition of pdf to the default line breaks the travis build.  This changes the default target so that it only builds txt and html by default.  You can get pdf by running `make pdf`.
