### PR TITLE
A bunch of editorial stuff

### DIFF
--- a/draft-thomson-sslv3-diediedie.md
+++ b/draft-thomson-sslv3-diediedie.md
@@ -136,14 +136,14 @@ ServerHello with ServerHello.server_version set to {03,00}.  Any party
 receiving a Hello message with the protocol version set to {03,00} MUST
 respond with a "protocol_version" alert message and close the connection.
 
-Historically, TLS specifications were not fully clear on what the record layer
-version number (TLSPlaintext.version) should contain when sending ClientHello
-(i.e., before it is known which version of the protocol will be employed).
-Appendix E of {{RFC5246}} provides some recommendations to maximize
-interoperability.  To the purpose of this document, such recommendations are
-still applicable.  In particular, TLS servers compliant with this document MUST
-accept any value {03,XX} (thus including {03,00}) as the record layer version
-number for ClientHello, but they MUST NOT negotiate SSLv3.
+Historically, TLS specifications were not clear on what the record layer version
+number (TLSPlaintext.version) could contain when sending ClientHello.  Appendix
+E of {{RFC5246}} notes that TLSPlaintext.version could be selected to maximize
+interoperability, though no definitive value is identified as ideal.  That
+guidance is still applicable; therefore, TLS servers MUST accept any value
+{03,XX} (including {03,00}) as the record layer version number for ClientHello,
+but they MUST NOT negotiate SSLv3.
+
 
 # A Litany of Attacks
 
@@ -198,11 +198,11 @@ cryptographic modes.  Of these, the following are particularly prominent:
 * Elliptic Curve Diffie-Hellman (ECDH) and Digital Signature Algorithm (ECDSA)
   are added in {{RFC4492}}.
 
-* Application layer protocol negotiation {{RFC7301}}.
-
 * Stateless session tickets {{RFC5077}}.
 
 * A datagram mode of operation, DTLS {{RFC6347}}.
+
+* Application layer protocol negotiation {{RFC7301}}.
 
 
 # IANA Considerations


### PR DESCRIPTION
The abbreviated title was naff (technical term, that).

Nikos rightly noted that the important stuff was somewhat buried in the intro.  I fixed that by adding a header.

Nikos also notes that we don't recommend an alternative.  I thought that was obvious, but added text anyway.

I thought that copy-paste from AppxE of 5246 was fine, but felt motivated to reword it a little.
